### PR TITLE
認証用関数の実装方法を修正

### DIFF
--- a/infrastructure/authentication.go
+++ b/infrastructure/authentication.go
@@ -15,7 +15,7 @@ func Authentication(ctx context.Context) (context.Context, error) {
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Unauthenticated,
-			"could not parsed auth token: %v",
+			"could not read auth token: %v",
 			err,
 		)
 	}

--- a/infrastructure/authentication.go
+++ b/infrastructure/authentication.go
@@ -5,7 +5,6 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"log"
 )
 
 const AuthTokenKey = "auth-token"
@@ -14,9 +13,6 @@ func Authentication(ctx context.Context) (context.Context, error) {
 	token, err := grpc_auth.AuthFromMD(ctx, "Bearer")
 
 	if err != nil {
-		log.Fatal(err)
-
-		// TODO この条件分岐に入った時にgRPCサーバーが停止するので改善する
 		return nil, status.Errorf(
 			codes.Unauthenticated,
 			"could not parsed auth token: %v",


### PR DESCRIPTION
# issue URL
https://github.com/keitakn/golang-grpc-server/issues/9

# やった事
認証失敗時にgRPCサーバーと通信出来ない状態になるので、その現象を修正。

# 原因
`log.Fatal(err)` が残っていただけだった・・・