### PR TITLE
認証、認可関数をもう少し実用的な形に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,31 @@ brew install grpcurl
 
 ```
 grpcurl -plaintext \
--H 'authorization: Bearer CatSecret9999' \
+-H 'authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.rTCH8cLoGxAm_xw68z-zXVKi9ie6xJn9tnVWjd_9ftE' \
 -d '{"catId":"moko"}' \
 localhost:9998 Cat.FindCuteCat
 ```
 
-認証パラメータに渡す `CatSecret9999` は文字列であれば何でも良いですが、何か文字列を渡さないと認証エラーになります。
+認証パラメータに渡す `authorization: Bearer` は有効なJWTである必要があります。
+
+https://jwt.io/ でJWTを作成します。
+
+payloadの中身ですが `{ sub: "1" }` のようにユーザーIDをセットします。
+
+参考までに以下のJWTを記載しておきます。
+
+```
+# { "sub": "1" }
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.rTCH8cLoGxAm_xw68z-zXVKi9ie6xJn9tnVWjd_9ftE
+
+# { "sub": "2" }
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyIn0.a7ktMGTybA32ykWHRvhp8FTEsBb-g3FN8aBB6FbgBo0
+
+# { "sub": "3" }
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzIn0.FYQ95U6iKXxxRIAydKNuDmxsQybrIQh-lXs6Cqs_97M
+```
+
+正常に認可されるのは `{ "sub": "1" }` のみで、それ以外はgRPCサーバーがエラーを返します。
 
 GUI製だと [BloomRPC](https://github.com/uw-labs/bloomrpc) が便利です。
 
@@ -60,7 +79,26 @@ GUI製だと [BloomRPC](https://github.com/uw-labs/bloomrpc) が便利です。
 
 左上のプラスボタンから `pb/cat.proto` をロードする事が可能です。
 
-<img width="1318" alt="BloomRPC" src="https://user-images.githubusercontent.com/11032365/74407093-9028fe80-4e74-11ea-9112-2371364140d7.png">
+![BloomRPC](https://user-images.githubusercontent.com/11032365/74523153-ea52be00-4f5f-11ea-94b7-944c6241dd7d.png)
+
+METADATAの部分にはauthorizationトークンをJSONで指定します。
+
+```
+# ユーザーID 1 これしか正常に認可が通らない
+{
+  "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.rTCH8cLoGxAm_xw68z-zXVKi9ie6xJn9tnVWjd_9ftE"
+}
+
+# ユーザーID 2
+{
+  "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyIn0.a7ktMGTybA32ykWHRvhp8FTEsBb-g3FN8aBB6FbgBo0"
+}
+
+# ユーザーID 3
+{
+  "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzIn0.FYQ95U6iKXxxRIAydKNuDmxsQybrIQh-lXs6Cqs_97M"
+}
+```
 
 ## `.proto` からGoのインターフェースを作成する
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/keitakn/golang-grpc-server
 go 1.13
 
 require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/golang/protobuf v1.3.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	google.golang.org/grpc v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/infrastructure/authentication.go
+++ b/infrastructure/authentication.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"context"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,14 +21,26 @@ func Authentication(ctx context.Context) (context.Context, error) {
 		)
 	}
 
-	return setAuthToken(ctx, token), nil
+	// サンプルなので署名検証はスキップ
+	// payloadにsubが含まれていれば問題なし
+	parser := new(jwt.Parser)
+	parsedToken, _, err := parser.ParseUnverified(token, &jwt.StandardClaims{})
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Unauthenticated,
+			"could not parsed auth token: %v",
+			err,
+		)
+	}
+
+	return setAuthToken(ctx, parsedToken.Claims.(*jwt.StandardClaims)), nil
 }
 
-func setAuthToken(ctx context.Context, token string) context.Context {
+func setAuthToken(ctx context.Context, token *jwt.StandardClaims) context.Context {
 	return context.WithValue(ctx, AuthTokenKey, token)
 }
 
-func GetAuthToken(ctx context.Context) (string, bool) {
-	val, ok := ctx.Value(AuthTokenKey).(string)
+func GetAuthToken(ctx context.Context) (*jwt.StandardClaims, bool) {
+	val, ok := ctx.Value(AuthTokenKey).(*jwt.StandardClaims)
 	return val, ok
 }

--- a/infrastructure/authorization.go
+++ b/infrastructure/authorization.go
@@ -5,7 +5,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"log"
 )
 
 var catMethodList = map[string][]string{
@@ -61,8 +60,6 @@ func canAccessToMethod(method string, user *User) bool {
 	for _, p := range user.permissions {
 		permissions[p] = true
 	}
-
-	log.Println(user.permissions)
 
 	for _, p := range r {
 		if !permissions[p] {

--- a/infrastructure/authorization.go
+++ b/infrastructure/authorization.go
@@ -8,6 +8,26 @@ import (
 	"log"
 )
 
+var catMethodList = map[string][]string{
+	"/Cat/FindCuteCat": {"FindCuteCat"},
+}
+
+type User struct {
+	permissions []string
+}
+
+// 本来はDB等からユーザーを検索する想定
+func findUser(id string) *User {
+	// 本番ではDBから取得する。
+	switch id {
+	case "1":
+		return &User{permissions: []string{"FindCuteCat"}}
+	case "2":
+		return &User{permissions: []string{"CreateCat"}}
+	}
+	return &User{}
+}
+
 func AuthorizationUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -18,10 +38,10 @@ func AuthorizationUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 		token, ok := GetAuthToken(ctx)
 		if ok == true {
 			// 認可処理としてはかなり雑だがサンプルなのでこれでいく
-			// 本来は info.FullMethod の値などを見て、対象のリクエストを許可して良いか判断する事になる
-			log.Print(token)
-			log.Println(info.FullMethod)
-			return handler(ctx, req)
+			user := findUser(token.Subject)
+			if canAccessToMethod(info.FullMethod, user) {
+				return handler(ctx, req)
+			}
 		}
 
 		return nil, status.Error(
@@ -29,4 +49,26 @@ func AuthorizationUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 			"could not access to specified method",
 		)
 	}
+}
+
+func canAccessToMethod(method string, user *User) bool {
+	r, ok := catMethodList[method]
+	if !ok {
+		return false
+	}
+
+	permissions := map[string]bool{}
+	for _, p := range user.permissions {
+		permissions[p] = true
+	}
+
+	log.Println(user.permissions)
+
+	for _, p := range r {
+		if !permissions[p] {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
# issue URL
https://github.com/keitakn/golang-grpc-server/issues/9

# やった事
gRPCの認証、認可関数の仕様を変更。

JWT形式のデータを受け取り、特定のユーザーID（sub）以外はgRPCメソッドの実行を拒否するように改修。

サンプルなので本格的な実装ではないが、実際に認可処理を実装する際の参考になる事を期待する。