### PR TITLE
アプリケーションログを出力するように改修

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/golang/protobuf v1.3.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
+	go.uber.org/zap v1.10.0
 	google.golang.org/grpc v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,11 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/infrastructure/logger.go
+++ b/infrastructure/logger.go
@@ -59,9 +59,9 @@ func AccessLogUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 		ctxzap.AddFields(
 			ctx,
-			zap.String("access.clientIp", clientIP),
-			zap.String("access.useragent", ua),
-			zap.String("access.authToken", authToken),
+			zap.String("access.ClientIp", clientIP),
+			zap.String("access.Useragent", ua),
+			zap.String("access.AuthToken", authToken),
 		)
 
 		return handler(ctx, req)

--- a/infrastructure/logger.go
+++ b/infrastructure/logger.go
@@ -1,0 +1,33 @@
+package infrastructure
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func CreateLogger() *zap.Logger {
+	level := zap.NewAtomicLevel()
+	level.SetLevel(zapcore.DebugLevel)
+
+	zapConfig := zap.Config{
+		Level:    level,
+		Encoding: "json",
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:        "Time",
+			LevelKey:       "Level",
+			NameKey:        "Name",
+			CallerKey:      "Caller",
+			MessageKey:     "Msg",
+			StacktraceKey:  "St",
+			EncodeLevel:    zapcore.CapitalLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		},
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stderr"},
+	}
+	logger, _ := zapConfig.Build()
+
+	return logger
+}

--- a/infrastructure/logger.go
+++ b/infrastructure/logger.go
@@ -53,13 +53,13 @@ func AccessLogUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 			}
 
 			if token, ok := md["authorization"]; ok {
-				authToken = token[0]
+				authToken = strings.Join(token, ",")
 			}
 		}
 
 		ctxzap.AddFields(
 			ctx,
-			zap.String("access.clientip", clientIP),
+			zap.String("access.clientIp", clientIP),
 			zap.String("access.useragent", ua),
 			zap.String("access.authToken", authToken),
 		)

--- a/infrastructure/logger.go
+++ b/infrastructure/logger.go
@@ -1,8 +1,14 @@
 package infrastructure
 
 import (
+	"context"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"strings"
 )
 
 func CreateLogger() *zap.Logger {
@@ -30,4 +36,34 @@ func CreateLogger() *zap.Logger {
 	logger, _ := zapConfig.Build()
 
 	return logger
+}
+
+func AccessLogUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		clientIP := "unknown"
+		if p, ok := peer.FromContext(ctx); ok {
+			clientIP = p.Addr.String()
+		}
+
+		ua := ""
+		authToken := ""
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if u, ok := md["user-agent"]; ok {
+				ua = strings.Join(u, ",")
+			}
+
+			if token, ok := md["authorization"]; ok {
+				authToken = token[0]
+			}
+		}
+
+		ctxzap.AddFields(
+			ctx,
+			zap.String("access.clientip", clientIP),
+			zap.String("access.useragent", ua),
+			zap.String("access.authToken", authToken),
+		)
+
+		return handler(ctx, req)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 	server := grpc.NewServer(
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpczap.UnaryServerInterceptor(zapLogger),
+			infrastructure.AccessLogUnaryServerInterceptor(),
 			grpc_auth.UnaryServerInterceptor(infrastructure.Authentication),
 			infrastructure.AuthorizationUnaryServerInterceptor(),
 		)),

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/keitakn/golang-grpc-server/infrastructure"
 	pb "github.com/keitakn/golang-grpc-server/pb"
 	"google.golang.org/grpc"
@@ -18,8 +19,11 @@ func main() {
 		log.Fatalf("failed to listen port: %v", err)
 	}
 
+	zapLogger := infrastructure.CreateLogger()
+
 	server := grpc.NewServer(
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+			grpczap.UnaryServerInterceptor(zapLogger),
 			grpc_auth.UnaryServerInterceptor(infrastructure.Authentication),
 			infrastructure.AuthorizationUnaryServerInterceptor(),
 		)),


### PR DESCRIPTION
# issue URL
https://github.com/keitakn/golang-grpc-server/issues/13

# やった事
`zap` を使ってログを出力する為の `UnaryServerInterceptor` を実装。